### PR TITLE
[INFRA-2817] Quick internal plugin to get GCE tags

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -141,15 +141,15 @@ require (
 	go.opentelemetry.io/otel/metric v0.27.0
 	go.opentelemetry.io/otel/sdk/metric v0.27.0
 	go.starlark.net v0.0.0-20210406145628-7a1108eaa012
-	golang.org/x/net v0.0.0-20211209124913-491a49abca63
+	golang.org/x/net v0.0.0-20220127200216-cd36cc0744dd
 	golang.org/x/oauth2 v0.0.0-20211104180415-d3ed0bb246c8
 	golang.org/x/sync v0.0.0-20210220032951-036812b2e83c
-	golang.org/x/sys v0.0.0-20220128215802-99c3d69c2c27
+	golang.org/x/sys v0.0.0-20220209214540-3681064d5158
 	golang.org/x/text v0.3.7
 	golang.zx2c4.com/wireguard/wgctrl v0.0.0-20211230205640-daad0b7ba671
 	gonum.org/v1/gonum v0.9.3
-	google.golang.org/api v0.67.0
-	google.golang.org/genproto v0.0.0-20220207164111-0872dc986b00
+	google.golang.org/api v0.70.0
+	google.golang.org/genproto v0.0.0-20220222213610-43724f9ea8cf
 	google.golang.org/grpc v1.44.0
 	google.golang.org/protobuf v1.27.1
 	gopkg.in/gorethink/gorethink.v3 v3.0.5
@@ -164,7 +164,7 @@ require (
 
 require (
 	cloud.google.com/go v0.100.2 // indirect
-	cloud.google.com/go/compute v0.1.0 // indirect
+	cloud.google.com/go/compute v1.5.0 // indirect
 	cloud.google.com/go/iam v0.1.1 // indirect
 	code.cloudfoundry.org/clock v1.0.0 // indirect
 	github.com/Azure/azure-amqp-common-go/v3 v3.2.3 // indirect
@@ -341,7 +341,6 @@ require (
 	golang.org/x/crypto v0.0.0-20220112180741-5e0467b6c7ce // indirect
 	golang.org/x/exp v0.0.0-20200513190911-00229845015e // indirect
 	golang.org/x/mod v0.5.1 // indirect
-	golang.org/x/term v0.0.0-20210615171337-6886f2dfbf5b // indirect
 	golang.org/x/time v0.0.0-20211116232009-f0f3c7e86c11 // indirect
 	golang.org/x/tools v0.1.8 // indirect
 	golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -43,6 +43,9 @@ cloud.google.com/go/bigquery v1.8.0/go.mod h1:J5hqkt3O0uAFnINi6JXValWIb1v0goeZM7
 cloud.google.com/go/bigtable v1.2.0/go.mod h1:JcVAOl45lrTmQfLj7T6TxyMzIN/3FGGcFm+2xVAli2o=
 cloud.google.com/go/compute v0.1.0 h1:rSUBvAyVwNJ5uQCKNJFMwPtTvJkfN38b6Pvb9zZoqJ8=
 cloud.google.com/go/compute v0.1.0/go.mod h1:GAesmwr110a34z04OlxYkATPBEfVhkymfTBXtfbBFow=
+cloud.google.com/go/compute v1.3.0/go.mod h1:cCZiE1NHEtai4wiufUhW8I8S1JKkAnhnQJWM7YD99wM=
+cloud.google.com/go/compute v1.5.0 h1:b1zWmYuuHz7gO9kDcM/EpHGr06UgsYNRpNJzI2kFiLM=
+cloud.google.com/go/compute v1.5.0/go.mod h1:9SMHyhJlzhlkJqrPAc839t2BZFTSk6Jdj6mkzQJeu0M=
 cloud.google.com/go/datastore v1.0.0/go.mod h1:LXYbyblFSglQ5pkeyhO+Qmw7ukd3C+pD7TKLgZqpHYE=
 cloud.google.com/go/datastore v1.1.0/go.mod h1:umbIZjpQpHh4hmRpGhH4tLFup+FVzqBi1b3c64qFpCk=
 cloud.google.com/go/firestore v1.1.0/go.mod h1:ulACoGHTpvq5r8rxGJ4ddJZBZqakUQqClKRT5SZwBmk=
@@ -2520,6 +2523,7 @@ golang.org/x/net v0.0.0-20211201190559-0a0e4e1bb54c/go.mod h1:9nx3DQGgdP8bBQD5qx
 golang.org/x/net v0.0.0-20211208012354-db4efeb81f4b/go.mod h1:9nx3DQGgdP8bBQD5qxJ1jj9UTztislL4KSBs9R2vV5Y=
 golang.org/x/net v0.0.0-20211209124913-491a49abca63 h1:iocB37TsdFuN6IBRZ+ry36wrkoV51/tl5vOWqkcPGvY=
 golang.org/x/net v0.0.0-20211209124913-491a49abca63/go.mod h1:9nx3DQGgdP8bBQD5qxJ1jj9UTztislL4KSBs9R2vV5Y=
+golang.org/x/net v0.0.0-20220127200216-cd36cc0744dd/go.mod h1:CfG3xpIq0wQ8r1q4Su4UZFWDARRcnwPjda9FqA0JpMk=
 golang.org/x/oauth2 v0.0.0-20180821212333-d2e6202438be/go.mod h1:N/0e6XlmueqKjAGxoOufVs8QHGRruUQn6yWY3a++T0U=
 golang.org/x/oauth2 v0.0.0-20190226205417-e64efc72b421/go.mod h1:gOpvHmFTYa4IltrdGE7lF6nIHvwfUNPOp7c8zoXwtLw=
 golang.org/x/oauth2 v0.0.0-20190604053449-0f29369cfe45/go.mod h1:gOpvHmFTYa4IltrdGE7lF6nIHvwfUNPOp7c8zoXwtLw=
@@ -2721,11 +2725,13 @@ golang.org/x/sys v0.0.0-20220111092808-5a964db01320/go.mod h1:oPkhp1MJrh7nUepCBc
 golang.org/x/sys v0.0.0-20220114195835-da31bd327af9/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220128215802-99c3d69c2c27 h1:XDXtA5hveEEV8JB2l7nhMTp3t3cHp9ZpwcdjqyEWLlo=
 golang.org/x/sys v0.0.0-20220128215802-99c3d69c2c27/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/sys v0.0.0-20220209214540-3681064d5158/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/term v0.0.0-20201117132131-f5c789dd3221/go.mod h1:Nr5EML6q2oocZ2LXRh80K7BxOlk5/8JxuGnuhpl+muw=
 golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=
 golang.org/x/term v0.0.0-20210220032956-6a3ed077a48d/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=
 golang.org/x/term v0.0.0-20210615171337-6886f2dfbf5b h1:9zKuko04nR4gjZ4+DNjHqRlAJqbJETHwiNKDqTfOjfE=
 golang.org/x/term v0.0.0-20210615171337-6886f2dfbf5b/go.mod h1:jbD1KX2456YbFQfuXm/mYQcufACuNUgVhRMnK/tPxf8=
+golang.org/x/term v0.0.0-20210927222741-03fcf44c2211/go.mod h1:jbD1KX2456YbFQfuXm/mYQcufACuNUgVhRMnK/tPxf8=
 golang.org/x/text v0.0.0-20170915032832-14c0d48ead0c/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.1-0.20180807135948-17ff2d5776d2/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
@@ -2930,6 +2936,7 @@ google.golang.org/api v0.63.0/go.mod h1:gs4ij2ffTRXwuzzgJl/56BdwJaA194ijkfn++9tD
 google.golang.org/api v0.64.0/go.mod h1:931CdxA8Rm4t6zqTFGSsgwbAEZ2+GMYurbndwSimebM=
 google.golang.org/api v0.67.0 h1:lYaaLa+x3VVUhtosaK9xihwQ9H9KRa557REHwwZ2orM=
 google.golang.org/api v0.67.0/go.mod h1:ShHKP8E60yPsKNw/w8w+VYaj9H6buA5UqDp8dhbQZ6g=
+google.golang.org/api v0.70.0/go.mod h1:Bs4ZM2HGifEvXwd50TtW70ovgJffJYw2oRCOFU/SkfA=
 google.golang.org/appengine v1.1.0/go.mod h1:EbEs0AVv82hx2wNQdGPgUI5lhzA/G0D9YwlJXL52JkM=
 google.golang.org/appengine v1.2.0/go.mod h1:xpcJRLb0r/rnEns0DIKYYv+WjYCduHsrkT7/EB5XEv4=
 google.golang.org/appengine v1.4.0/go.mod h1:xpcJRLb0r/rnEns0DIKYYv+WjYCduHsrkT7/EB5XEv4=
@@ -3020,6 +3027,8 @@ google.golang.org/genproto v0.0.0-20220111164026-67b88f271998/go.mod h1:5CzLGKJ6
 google.golang.org/genproto v0.0.0-20220126215142-9970aeb2e350/go.mod h1:5CzLGKJ67TSI2B9POpiiyGha0AjJvZIUgRMt1dSmuhc=
 google.golang.org/genproto v0.0.0-20220207164111-0872dc986b00 h1:zmf8Yq9j+IyTpps+paSkmHkSu5fJlRKy69LxRzc17Q0=
 google.golang.org/genproto v0.0.0-20220207164111-0872dc986b00/go.mod h1:5CzLGKJ67TSI2B9POpiiyGha0AjJvZIUgRMt1dSmuhc=
+google.golang.org/genproto v0.0.0-20220218161850-94dd64e39d7c/go.mod h1:kGP+zUP2Ddo0ayMi4YuN7C3WZyJvGLZRh8Z5wnAqvEI=
+google.golang.org/genproto v0.0.0-20220222213610-43724f9ea8cf/go.mod h1:kGP+zUP2Ddo0ayMi4YuN7C3WZyJvGLZRh8Z5wnAqvEI=
 google.golang.org/grpc v0.0.0-20160317175043-d3ddb4469d5a/go.mod h1:yo6s7OP7yaDglbqo1J04qKzAhqBH6lvTonzMVmEdcZw=
 google.golang.org/grpc v1.8.0/go.mod h1:yo6s7OP7yaDglbqo1J04qKzAhqBH6lvTonzMVmEdcZw=
 google.golang.org/grpc v1.17.0/go.mod h1:6QZJwpn2B+Zp71q/5VxRsJ6NXXVCE5NRUHRo+f3cWCs=

--- a/plugins/processors/gce/README.md
+++ b/plugins/processors/gce/README.md
@@ -1,0 +1,67 @@
+# AWS EC2 Metadata Processor Plugin
+
+AWS EC2 Metadata processor plugin appends metadata gathered from [AWS IMDS][]
+to metrics associated with EC2 instances.
+
+[AWS IMDS]: https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-instance-metadata.html
+
+## Configuration
+
+```toml
+[[processors.aws_ec2]]
+  ## Available tags:
+  ## * accountId
+  ## * architecture
+  ## * availabilityZone
+  ## * billingProducts
+  ## * imageId
+  ## * instanceId
+  ## * instanceType
+  ## * kernelId
+  ## * pendingTime
+  ## * privateIp
+  ## * ramdiskId
+  ## * region
+  ## * version
+  imds_tags = []
+
+  ## EC2 instance tags retrieved with DescribeTags action.
+  ## In case tag is empty upon retrieval it's omitted when tagging metrics.
+  ## Note that in order for this to work, role attached to EC2 instance or AWS
+  ## credentials available from the environment must have a policy attached, that
+  ## allows ec2:DescribeTags.
+  ##
+  ## For more information see:
+  ## https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_DescribeTags.html
+  ec2_tags = []
+
+  ## Timeout for http requests made by against aws ec2 metadata endpoint.
+  timeout = "10s"
+
+  ## ordered controls whether or not the metrics need to stay in the same order
+  ## this plugin received them in. If false, this plugin will change the order
+  ## with requests hitting cached results moving through immediately and not
+  ## waiting on slower lookups. This may cause issues for you if you are
+  ## depending on the order of metrics staying the same. If so, set this to true.
+  ## Keeping the metrics ordered may be slightly slower.
+  ordered = false
+
+  ## max_parallel_calls is the maximum number of AWS API calls to be in flight
+  ## at the same time.
+  ## It's probably best to keep this number fairly low.
+  max_parallel_calls = 10
+```
+
+## Example
+
+Append `accountId` and `instanceId` to metrics tags:
+
+```toml
+[[processors.aws_ec2]]
+  tags = [ "accountId", "instanceId"]
+```
+
+```diff
+- cpu,hostname=localhost time_idle=42
++ cpu,hostname=localhost,accountId=123456789,instanceId=i-123456789123 time_idle=42
+```

--- a/plugins/processors/gce/README.md
+++ b/plugins/processors/gce/README.md
@@ -1,41 +1,23 @@
-# AWS EC2 Metadata Processor Plugin
+# GCE Metadata Processor Plugin
 
-AWS EC2 Metadata processor plugin appends metadata gathered from [AWS IMDS][]
-to metrics associated with EC2 instances.
-
-[AWS IMDS]: https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-instance-metadata.html
+GCE Metadata processor plugin appends metadata gathered from Google Cloud
+to metrics associated with GCE instances.
 
 ## Configuration
 
 ```toml
-[[processors.aws_ec2]]
-  ## Available tags:
-  ## * accountId
-  ## * architecture
-  ## * availabilityZone
-  ## * billingProducts
-  ## * imageId
-  ## * instanceId
-  ## * instanceType
-  ## * kernelId
-  ## * pendingTime
-  ## * privateIp
-  ## * ramdiskId
-  ## * region
-  ## * version
-  imds_tags = []
-
-  ## EC2 instance tags retrieved with DescribeTags action.
-  ## In case tag is empty upon retrieval it's omitted when tagging metrics.
-  ## Note that in order for this to work, role attached to EC2 instance or AWS
-  ## credentials available from the environment must have a policy attached, that
-  ## allows ec2:DescribeTags.
-  ##
+  ## GCP Instance and project metadata to attach to metrics as tags.
   ## For more information see:
-  ## https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_DescribeTags.html
-  ec2_tags = []
+  ## https://cloud.google.com/compute/docs/metadata/default-metadata-values
+  ##
+  ## Available tags:
+  ## * zone
+  ## * tags
+  ## * name
+  ## * hostname
+  allow_tags = []
 
-  ## Timeout for http requests made by against aws ec2 metadata endpoint.
+  ## Timeout for http requests made by against gce metadata endpoint.
   timeout = "10s"
 
   ## ordered controls whether or not the metrics need to stay in the same order
@@ -50,18 +32,4 @@ to metrics associated with EC2 instances.
   ## at the same time.
   ## It's probably best to keep this number fairly low.
   max_parallel_calls = 10
-```
-
-## Example
-
-Append `accountId` and `instanceId` to metrics tags:
-
-```toml
-[[processors.aws_ec2]]
-  tags = [ "accountId", "instanceId"]
-```
-
-```diff
-- cpu,hostname=localhost time_idle=42
-+ cpu,hostname=localhost,accountId=123456789,instanceId=i-123456789123 time_idle=42
 ```

--- a/plugins/processors/gce/gce.go
+++ b/plugins/processors/gce/gce.go
@@ -1,0 +1,184 @@
+package ec2
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+	"time"
+
+	"cloud.google.com/go/compute/metadata"
+
+	"github.com/influxdata/telegraf"
+	"github.com/influxdata/telegraf/config"
+	"github.com/influxdata/telegraf/plugins/common/parallel"
+	"github.com/influxdata/telegraf/plugins/processors"
+)
+
+type GceProcessor struct {
+	AllowTags        []string        `toml:"allow_tags"`
+	Timeout          config.Duration `toml:"timeout"`
+	Ordered          bool            `toml:"ordered"`
+	MaxParallelCalls int             `toml:"max_parallel_calls"`
+	Log              telegraf.Logger `toml:"-"`
+
+	gceClient    *metadata.Client
+	allowTagsMap map[string]struct{}
+	parallel     parallel.Parallel
+	instanceID   string
+}
+
+const sampleConfig = `
+  ## GCP Instance and project metadata to attach to metrics as tags.
+  ## For more information see:
+  ## https://cloud.google.com/compute/docs/metadata/default-metadata-values
+  ##
+  ## Available tags:
+  ## * zone
+  ## * tags
+  ## * name
+  ## * hostname
+  allow_tags = []
+
+  ## Timeout for http requests made by against gce metadata endpoint.
+  timeout = "10s"
+
+  ## ordered controls whether or not the metrics need to stay in the same order
+  ## this plugin received them in. If false, this plugin will change the order
+  ## with requests hitting cached results moving through immediately and not
+  ## waiting on slower lookups. This may cause issues for you if you are
+  ## depending on the order of metrics staying the same. If so, set this to true.
+  ## Keeping the metrics ordered may be slightly slower.
+  ordered = false
+
+  ## max_parallel_calls is the maximum number of AWS API calls to be in flight
+  ## at the same time.
+  ## It's probably best to keep this number fairly low.
+  max_parallel_calls = 10
+`
+
+const (
+	DefaultMaxOrderedQueueSize = 10_000
+	DefaultMaxParallelCalls    = 10
+	DefaultTimeout             = 10 * time.Second
+)
+
+var permittedTags = map[string]struct{}{
+	"zone":     {},
+	"tags":     {},
+	"name":     {},
+	"hostname": {},
+}
+
+func (r *GceProcessor) SampleConfig() string {
+	return sampleConfig
+}
+
+func (r *GceProcessor) Description() string {
+	return "Attach GCE metadata to metrics"
+}
+
+func (r *GceProcessor) Add(metric telegraf.Metric, _ telegraf.Accumulator) error {
+	r.parallel.Enqueue(metric)
+	return nil
+}
+
+func (r *GceProcessor) Init() error {
+	r.Log.Debug("Initializing GCE Processor")
+	for _, tag := range r.AllowTags {
+		if len(tag) == 0 || !isTagPermitted(tag) {
+			return fmt.Errorf("un-permitted metadata tag specified in configuration: %s", tag)
+		}
+		r.allowTagsMap[tag] = struct{}{}
+	}
+
+	return nil
+}
+
+func (r *GceProcessor) Start(acc telegraf.Accumulator) error {
+	r.gceClient = metadata.NewClient(nil)
+
+	if r.Ordered {
+		r.parallel = parallel.NewOrdered(acc, r.asyncAdd, DefaultMaxOrderedQueueSize, r.MaxParallelCalls)
+	} else {
+		r.parallel = parallel.NewUnordered(acc, r.asyncAdd, r.MaxParallelCalls)
+	}
+
+	return nil
+}
+
+func (r *GceProcessor) Stop() error {
+	if r.parallel == nil {
+		return errors.New("trying to stop unstarted GCE Processor")
+	}
+	r.parallel.Stop()
+	return nil
+}
+
+func (r *GceProcessor) asyncAdd(metric telegraf.Metric) []telegraf.Metric {
+	_, cancel := context.WithTimeout(context.Background(), time.Duration(r.Timeout))
+	defer cancel()
+
+	if len(r.allowTagsMap) > 0 {
+		for tag := range r.allowTagsMap {
+			fmt.Println(tag)
+			val, err := r.getTagFromGCE(tag)
+			if err != nil {
+				panic(err)
+			}
+			metric.AddTag(tag, val)
+		}
+	}
+
+	return []telegraf.Metric{metric}
+}
+
+func init() {
+	processors.AddStreaming("aws_ec2", func() telegraf.StreamingProcessor {
+		return newGceProcessor()
+	})
+}
+
+func newGceProcessor() *GceProcessor {
+	return &GceProcessor{
+		MaxParallelCalls: DefaultMaxParallelCalls,
+		Timeout:          config.Duration(DefaultTimeout),
+		allowTagsMap:     make(map[string]struct{}),
+	}
+}
+
+func (r *GceProcessor) getTagFromGCE(tag string) (string, error) {
+	switch tag {
+	case "zone":
+		zone, err := r.gceClient.Zone()
+		if err != nil {
+			return "", err
+		}
+		return strings.Split(zone, "/")[3], nil
+	case "tags":
+		instance_tags, err := r.gceClient.InstanceTags()
+		if err != nil {
+			return "", err
+		}
+		return strings.Join(instance_tags, ","), nil
+	case "name":
+		name, err := r.gceClient.InstanceName()
+		if err != nil {
+			return "", err
+		}
+		return name, nil
+	case "hostname":
+		hostname, err := r.gceClient.Hostname()
+		if err != nil {
+			return "", err
+		}
+		return hostname, nil
+	default:
+		return "", nil
+	}
+}
+
+func isTagPermitted(tag string) bool {
+	_, ok := permittedTags[tag]
+	return ok
+}


### PR DESCRIPTION
This PR adds a 'quick and dirty' Telegraf processor for GCE instance and project tags.

We only provide a few tags in this first release, namely: 
```
	"zone":     {},
	"tags":     {},
	"name":     {},
	"hostname": {},
```
Some string processing is done on `tags` and `zone` so they might better fit our expectations.

Additional tags can be added later, there is a list [here](https://pkg.go.dev/cloud.google.com/go/compute@v1.5.0/metadata#pkg-overview).
